### PR TITLE
fix: Disable Automatic Analysis to Resolve Conflict with CI Analysis merge develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,18 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox and any other packages
+        run: pip install tox
+      - name: Run tox
+        run: tox -e py
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=huynhngoanhthai_AIO-EXERCISE
 sonar.organization=huynhngoanhthai
+sonar.python.coverage.reportPaths=coverage.xml
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=AIO-EXERCISE

--- a/test_tmp.py
+++ b/test_tmp.py
@@ -1,0 +1,2 @@
+def test_example_function():
+    assert True == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py311
+skipsdist = True
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+commands = pytest --cov=AIO-EXERCISE --cov-report=xml --cov-config=tox.ini --cov-branch


### PR DESCRIPTION
This commit resolves the issue of running CI analysis while Automatic Analysis is enabled, which causes conflicts and redundancy. By disabling Automatic Analysis, we ensure that only CI analysis runs, streamlining the process and avoiding duplication.

- Disabled Automatic Analysis.
- Ensured that CI analysis is the sole process for code quality checks.

These changes improve the efficiency of the analysis process and prevent conflicts between different analysis tools.
